### PR TITLE
[Groups Feature] - Data models/routes for groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -62,7 +62,15 @@ class GroupsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_group
-      @group = Group.find(params[:id])
+      begin
+        @group = current_user.owned_groups.find(params[:id])
+      rescue ActiveRecord::RecordNotFound => e
+        puts "Can't access this page! Invalid login."
+        redirect_to "/404.html"
+      rescue => exception
+        puts "ERROR! -> #{exception}"
+      end
+      
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,72 @@
+class GroupsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_group, only: %i[ show edit update destroy ]
+
+  # GET /groups or /groups.json
+  def index
+    @groups = Group.all
+  end
+
+  # GET /groups/1 or /groups/1.json
+  def show
+  end
+
+  # GET /groups/new
+  def new
+    @group = Group.new
+  end
+
+  # GET /groups/1/edit
+  def edit
+  end
+
+  # POST /groups or /groups.json
+  def create
+    @group = Group.new(group_params)
+    @group.owner = current_user
+
+    respond_to do |format|
+      if @group.save
+        format.html { redirect_to group_url(@group), notice: "Group was successfully created." }
+        format.json { render :show, status: :created, location: @group }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @group.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /groups/1 or /groups/1.json
+  def update
+    respond_to do |format|
+      if @group.update(group_params)
+        format.html { redirect_to group_url(@group), notice: "Group was successfully updated." }
+        format.json { render :show, status: :ok, location: @group }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @group.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /groups/1 or /groups/1.json
+  def destroy
+    @group.destroy
+
+    respond_to do |format|
+      format.html { redirect_to groups_url, notice: "Group was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_group
+      @group = Group.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def group_params
+      params.require(:group).permit(:group_name)
+    end
+end

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -1,0 +1,2 @@
+module GroupsHelper
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,12 +7,10 @@ import Rails from "@rails/ujs"
 import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
-require("jquery")
+// require("jquery")
 
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()
 
-
-import "bootstrap"
 import "stylesheets/application"

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,12 @@
 class Group < ApplicationRecord
   belongs_to :owner, class_name: 'User', foreign_key: :user_id
-  has_many :subscriptions
+
+  # sets up tables members (to access membership records) and users (to access the users that belong to the group)
   has_many :members, class_name: 'Membership'
   has_many :users, through: :members
+
+  # sets up tables shared_subscriptions (to access shared_subscriptions records) 
+  # and subscriptions (to access the actual subscriptions that have been added to the group)
+  has_many :shared_subscriptions, dependent: :destroy
+  has_many :subscriptions, through: :shared_subscriptions
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,6 @@
+class Group < ApplicationRecord
+  belongs_to :owner, class_name: 'User', foreign_key: :user_id
+  has_many :subscriptions
+  has_many :members, class_name: 'Membership'
+  has_many :users, through: :members
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -9,4 +9,6 @@ class Group < ApplicationRecord
   # and subscriptions (to access the actual subscriptions that have been added to the group)
   has_many :shared_subscriptions, dependent: :destroy
   has_many :subscriptions, through: :shared_subscriptions
+  
+	validate :owner
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,0 +1,4 @@
+class Membership < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
+end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,4 +1,6 @@
 class Membership < ApplicationRecord
   belongs_to :user
   belongs_to :group
+
+  validates :group_id, :uniqueness => {:scope=>:user_id}
 end

--- a/app/models/shared_subscription.rb
+++ b/app/models/shared_subscription.rb
@@ -1,4 +1,6 @@
 class SharedSubscription < ApplicationRecord
   belongs_to :subscription
   belongs_to :group
+
+  validates :group_id, :uniqueness => {:scope=>:subscription_id}
 end

--- a/app/models/shared_subscription.rb
+++ b/app/models/shared_subscription.rb
@@ -1,0 +1,4 @@
+class SharedSubscription < ApplicationRecord
+  belongs_to :subscription
+  belongs_to :group
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -2,7 +2,8 @@ class Subscription < ApplicationRecord
 	has_kms_key
 	
   belongs_to :user
-  has_many :groups
+  has_many :share_records, class_name: 'SharedSubscription', :dependent => :delete_all 
+  has_many :groups, through: :share_records
 
   # attr_encrypted_options.merge!(encryptor: SubscriptionEncryptor, encrypt_method: :encrypt, decrypt_method: :decrypt)
   attr_encrypted :username, key: Rails.env.test? ? '2K31QRnurJBWvtWkTE3uXfKA7vivrvA5' : :kms_key

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -2,6 +2,7 @@ class Subscription < ApplicationRecord
 	has_kms_key
 	
   belongs_to :user
+  has_many :groups
 
   # attr_encrypted_options.merge!(encryptor: SubscriptionEncryptor, encrypt_method: :encrypt, decrypt_method: :decrypt)
   attr_encrypted :username, key: Rails.env.test? ? '2K31QRnurJBWvtWkTE3uXfKA7vivrvA5' : :kms_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,5 +30,8 @@ class User < ApplicationRecord
 			:timeoutable, :omniauthable
 	validates_uniqueness_of :username
 	
-	has_many :subscriptions
+	has_many :subscriptions, dependent: :destroy
+	has_many :owned_groups, class_name: 'Group'
+	has_many :memberships, dependent: :destroy
+	has_many :groups, through: :memberships, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,10 @@ class User < ApplicationRecord
 	validates_uniqueness_of :username
 	
 	has_many :subscriptions, dependent: :destroy
-	has_many :owned_groups, class_name: 'Group'
+	has_many :owned_groups, class_name: 'Group', inverse_of: 'owner', dependent: :destroy
 	has_many :memberships, dependent: :destroy
-	has_many :groups, through: :memberships, dependent: :destroy
+	has_many :groups, through: :memberships
+	
+	accepts_nested_attributes_for :subscriptions
+	accepts_nested_attributes_for :owned_groups
 end

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: group) do |form| %>
+  <% if group.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(group.errors.count, "error") %> prohibited this group from being saved:</h2>
+
+      <ul>
+        <% group.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :group_name %>
+    <%= form.text_field :group_name %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/groups/_group.json.jbuilder
+++ b/app/views/groups/_group.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! group, :id, :group_name, :user_id, :created_at, :updated_at
+json.url group_url(group, format: :json)

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Group</h1>
+
+<%= render 'form', group: @group %>
+
+<%= link_to 'Show', @group %> |
+<%= link_to 'Back', groups_path %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,0 +1,29 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Groups</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Group name</th>
+      <th>Owner</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @groups.each do |group| %>
+      <tr>
+        <td><%= group.group_name %></td>
+        <td><%= group.owner.username %></td>
+        <td><%= link_to 'Show', group %></td>
+        <td><%= link_to 'Edit', edit_group_path(group) %></td>
+        <td><%= link_to 'Destroy', group, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Group', new_group_path %>

--- a/app/views/groups/index.json.jbuilder
+++ b/app/views/groups/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @groups, partial: "groups/group", as: :group

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Group</h1>
+
+<%= render 'form', group: @group %>
+
+<%= link_to 'Back', groups_path %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,0 +1,14 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Group name:</strong>
+  <%= @group.group_name %>
+</p>
+
+<p>
+  <strong>Owner:</strong>
+  <%= @group.owner.username %>
+</p>
+
+<%= link_to 'Edit', edit_group_path(@group) %> |
+<%= link_to 'Back', groups_path %>

--- a/app/views/groups/show.json.jbuilder
+++ b/app/views/groups/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "groups/group", group: @group

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,9 +12,12 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@100;300;500;700&display=swap" rel="stylesheet">
   
+    <%# <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" rel="stylesheet" /> %>
 
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js"></script>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
 </head>
 

--- a/app/views/users/registrations/_edit.html.erb
+++ b/app/views/users/registrations/_edit.html.erb
@@ -1,48 +1,51 @@
 
 <%= render :layout => 'users/shared/cards' do %>
-
-  <h2 class="card-title">Edit Account</h2>
+ 
+  <button class="btn" type="button" data-toggle="collapse" data-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
+    <h2 class="card-title">Edit Account</h2>
+  </button>
   <hr/>
+  <div class="collapse" id="collapseExample">
 
-  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-    <%= render "users/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "users/shared/error_messages", resource: resource %>
 
-    <div class="field">
-      <%= f.label :email %><br />
-      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-    </div>
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      </div>
 
-    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-    <% end %>
-
-    <div class="field">
-      <%= f.label :password %><br />
-      <%= f.password_field :password, autocomplete: "new-password", placeholder:"leave blank if you don't want to change it" %>
-      <% if @minimum_password_length %>
-        <br />
-        <em><%= @minimum_password_length %> characters minimum</em>
+      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+        <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
       <% end %>
-    </div>
 
-    <div class="field">
-      <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder:"leave blank if you don't want to change it" %>
-    </div>
+      <div class="field">
+        <%= f.label :password %><br />
+        <%= f.password_field :password, autocomplete: "new-password", placeholder:"leave blank if you don't want to change it" %>
+        <% if @minimum_password_length %>
+          <br />
+          <em><%= @minimum_password_length %> characters minimum</em>
+        <% end %>
+      </div>
 
-    <div class="field">
-      <%= f.label :current_password %> <br />
-      <%= f.password_field :current_password, autocomplete: "current-password", placeholder:"we need your current password in order to update" %>
-    </div>
+      <div class="field">
+        <%= f.label :password_confirmation %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder:"leave blank if you don't want to change it" %>
+      </div>
 
-    <div class="actions">
-      <%= f.submit "Update", class: "btn btn-dark" %>
-    </div>
-  <% end %>
+      <div class="field">
+        <%= f.label :current_password %> <br />
+        <%= f.password_field :current_password, autocomplete: "current-password", placeholder:"we need your current password in order to update" %>
+      </div>
 
+      <div class="actions">
+        <%= f.submit "Update", class: "btn btn-dark" %>
+      </div>
+    <% end %>
+  </div>
 
   <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: "btn btn-dark" %>
 
-  <%= link_to "Back", :back %>
+  <%# <%= link_to "Back", :back %>
 
 <% end %>

--- a/app/views/users/registrations/_show.html.erb
+++ b/app/views/users/registrations/_show.html.erb
@@ -4,7 +4,11 @@
   <p>User: <%= resource.first_name + " " + resource.last_name%></p>
   <p>Username: <%= resource.username%></p>
   <p>Email: <%= resource.email%></p>
+
+  <hr/>
   
+  <%= button_to "Subscriptions", subscription_root_path, method: :get, class: "btn btn-dark" %>
+  <%= button_to "Groups", group_root_path, method: :get, class: "btn btn-dark" %>
 
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  	resources :groups
   	resources :subscriptions
 	devise_for :users, controllers: {
 		omniauth_callbacks: "users/omniauth_callbacks",
@@ -6,6 +7,7 @@ Rails.application.routes.draw do
 	}
 
 	get 'users/:username' => 'users#show', :as => :user_root
+	get 'groups/' => 'groups#index', :as => :group_root
 	get 'subscriptions/' => 'subscriptions#index', :as => :subscription_root
 
 	get 'home/index'

--- a/db/migrate/20220204032204_create_groups.rb
+++ b/db/migrate/20220204032204_create_groups.rb
@@ -2,8 +2,8 @@ class CreateGroups < ActiveRecord::Migration[6.1]
   def change
     create_table :groups, id: :uuid do |t|
       t.string :group_name
-      t.references :user, null: false, foreign_key: true, type: :uuid
-      
+      t.references :user, null: false, foreign_key: {on_delete: :cascade}, type: :uuid
+
       t.timestamps
     end
   end

--- a/db/migrate/20220204032204_create_groups.rb
+++ b/db/migrate/20220204032204_create_groups.rb
@@ -1,0 +1,10 @@
+class CreateGroups < ActiveRecord::Migration[6.1]
+  def change
+    create_table :groups, id: :uuid do |t|
+      t.string :group_name
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220204033137_create_memberships.rb
+++ b/db/migrate/20220204033137_create_memberships.rb
@@ -1,0 +1,10 @@
+class CreateMemberships < ActiveRecord::Migration[6.1]
+  def change
+    create_table :memberships, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.references :group, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220204033137_create_memberships.rb
+++ b/db/migrate/20220204033137_create_memberships.rb
@@ -1,8 +1,8 @@
 class CreateMemberships < ActiveRecord::Migration[6.1]
   def change
     create_table :memberships, id: :uuid do |t|
-      t.references :user, null: false, foreign_key: true, type: :uuid
-      t.references :group, null: false, foreign_key: true, type: :uuid
+      t.references :user, null: false, foreign_key: {on_delete: :cascade}, type: :uuid
+      t.references :group, null: false, foreign_key: {on_delete: :cascade}, type: :uuid
 
       t.timestamps
     end

--- a/db/migrate/20220204201708_create_shared_subscriptions.rb
+++ b/db/migrate/20220204201708_create_shared_subscriptions.rb
@@ -1,0 +1,10 @@
+class CreateSharedSubscriptions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :shared_subscriptions, id: :uuid do |t|
+      t.references :subscription, null: false, foreign_key: {on_delete: :cascade}, type: :uuid
+      t.references :group, null: false, foreign_key: {on_delete: :cascade}, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_30_200633) do
+ActiveRecord::Schema.define(version: 2022_02_04_033137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "groups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "group_name"
+    t.uuid "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_groups_on_user_id"
+  end
+
+  create_table "memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.uuid "group_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["group_id"], name: "index_memberships_on_group_id"
+    t.index ["user_id"], name: "index_memberships_on_user_id"
+  end
 
   create_table "subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "user_id", null: false
@@ -54,5 +71,8 @@ ActiveRecord::Schema.define(version: 2022_01_30_200633) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "groups", "users"
+  add_foreign_key "memberships", "groups"
+  add_foreign_key "memberships", "users"
   add_foreign_key "subscriptions", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_04_033137) do
+ActiveRecord::Schema.define(version: 2022_02_04_201708) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -31,6 +31,15 @@ ActiveRecord::Schema.define(version: 2022_02_04_033137) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["group_id"], name: "index_memberships_on_group_id"
     t.index ["user_id"], name: "index_memberships_on_user_id"
+  end
+
+  create_table "shared_subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "subscription_id", null: false
+    t.uuid "group_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["group_id"], name: "index_shared_subscriptions_on_group_id"
+    t.index ["subscription_id"], name: "index_shared_subscriptions_on_subscription_id"
   end
 
   create_table "subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -71,8 +80,10 @@ ActiveRecord::Schema.define(version: 2022_02_04_033137) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
-  add_foreign_key "groups", "users"
-  add_foreign_key "memberships", "groups"
-  add_foreign_key "memberships", "users"
+  add_foreign_key "groups", "users", on_delete: :cascade
+  add_foreign_key "memberships", "groups", on_delete: :cascade
+  add_foreign_key "memberships", "users", on_delete: :cascade
+  add_foreign_key "shared_subscriptions", "groups", on_delete: :cascade
+  add_foreign_key "shared_subscriptions", "subscriptions", on_delete: :cascade
   add_foreign_key "subscriptions", "users"
 end

--- a/features/groups/create_group.feature
+++ b/features/groups/create_group.feature
@@ -1,0 +1,18 @@
+Feature: Create Subscription
+	As an existing user
+    I want to be able to create groups
+    So that I can share usernames and passwords in Gatekeeper
+	Background: users exist
+		Given I exist as a user
+		And I am logged in
+
+    Scenario: User can see the new group form
+		Given I am on the groups "index" page
+		When I click the "New Group" link
+  		Then I should see the new group page
+
+    Scenario: User creates a group successfully
+		Given I am on the groups "new" page
+		When I create a new group
+		And I click the "Create Group" button
+  		Then I should see the "Roomies" group's show page

--- a/features/groups/delete_group.feature
+++ b/features/groups/delete_group.feature
@@ -1,0 +1,23 @@
+Feature: Delete Group
+	As an existing user
+    I want to be able to delete groups
+    So that I can remove usernames and passwords from Gatekeeper
+
+	Background: users have groups
+		Given I am logged in
+		And the following groups exist for user with email "manny@testerman.com":
+		| group_name	|
+		| Test Family	|
+		
+    Scenario: User deletes a group successfully
+	    Given I am on my profile page
+		When I click the "Groups" button
+		And I delete the "Test Family" group
+  		Then the "Test Family" group should not exist
+	
+    Scenario: User tries to view a deleted group
+	    Given I am on my profile page
+		When I click the "Groups" button
+		And I delete the "Test Family" group
+		And I view the "Test Family" group
+  		Then I should see the resource not found page

--- a/features/groups/view_group.feature
+++ b/features/groups/view_group.feature
@@ -1,0 +1,34 @@
+Feature: View Group
+	As an existing user
+    I want to be able to view groups
+    So that I can see usernames and passwords on Gatekeeper
+
+	Background: users have groups
+		Given the test users exist
+		And I am logged in
+		And the following groups exist for user with email "manny@testerman.com":
+		| group_name	|
+		| Test Family	| 
+		And the following groups exist for user with email "sarah@testerwoman.com":
+		| group_name	|
+		| Roommates		| 
+    Scenario: Signed in user can view group homepage
+	    Given I am on my profile page
+		When I click the "Groups" button
+  		Then I should see my groups
+
+    Scenario: User views a group successfully
+	    Given I am on my profile page
+		When I click the "Groups" button
+		And I view the "Test Family" group
+  		Then I should see the "Test Family" group's show page
+	
+    Scenario: User tries to view another user's group
+	    Given I am on the homepage
+		When I view the "Roommates" group
+  		Then I should see the resource not found page
+	
+    Scenario: Unauthenticated user tries to view a group
+		Given I am not logged in
+		When I view the "Test Family" group
+  		Then I am on the sign in page

--- a/features/step_definitions/group_steps.rb
+++ b/features/step_definitions/group_steps.rb
@@ -1,0 +1,87 @@
+# include user_steps
+
+def create_groups(user, group_table) 
+	group_table.hashes.each do |group|
+		user.owned_groups.create group
+	end
+end
+
+##### GIVEN #####
+Given /the following groups exist for user with email "(.*)"/ do |user_email, group_table|
+	user ||= User.where(:email => user_email).first
+	if (!user.nil?) 
+		create_groups(user, group_table)
+	end
+end
+
+Given /I am on the groups "(.*)" page/ do |page|
+	path = ""
+	if (page == "index") 
+		path = "groups##{page}"
+	else
+		path = "groups/#{page}"
+	end
+	visit path
+	if (page == "index") 
+		current_path.should eq("/groups")
+	end
+end
+
+##### WHEN #####
+When /^I view the "(.*)" group$/ do |group_name|
+	if (@group_id.nil?)
+		if (@group.nil?)
+			@group = Group.where(:group_name => group_name).first
+		end
+		expect(@group.nil? == false)
+		@group_id = @group.id
+	end
+	path = "/groups/" + @group_id
+	visit path
+end
+
+When /^I delete the "(.*)" group$/ do |group_name|
+	@group = Group.where(:group_name => group_name).first
+	@group_id = @group.id
+	puts "Group_ID=#{@group_id}"
+	click_link "Destroy"
+end
+
+When /^I create a new group$/ do
+	fill_in "group_group_name", :with => "Roomies"
+end
+
+
+##### THEN #####
+Then /^I should see my groups$/ do
+	path = "/groups"
+	visit path
+	for group in @user.groups
+		page.should have_content(group.group_name)
+		page.should have_content(group.owner.username)
+	end
+end
+
+Then /^I should see the "(.*)" group$/ do |group_name|
+	group = Group.where(:group_name => group_name).first
+	page.should have_content(group.group_name)
+	page.should have_content(group.owner.username)
+end
+
+Then /^the "(.*)" group should not exist$/ do |group_name|
+	group = Group.where(:group_name => group_name).first
+	expect(group.nil?)
+end
+
+Then /^I should see the "(.*)" group's show page$/ do |group_name|
+	group_id = URI.parse(current_url).path.split('/').last
+	group = Group.where(:id => group_id).first
+	expect(!group.nil?)
+	expect(group.group_name == group_name)
+	page.should have_content(group.group_name)
+	page.should have_content(group.owner.username)
+end
+
+Then /^I should see the new group page$/ do
+	page.should have_content("New Group")
+end

--- a/features/step_definitions/subscription_steps.rb
+++ b/features/step_definitions/subscription_steps.rb
@@ -15,7 +15,6 @@ Given /the following subscriptions exist for user with email "(.*)"/ do |user_em
 end
 
 Given /I am on the subscriptions "(.*)" page/ do |page|
-	# puts user_email
 	path = ""
 	if (page == "index") 
 		path = "subscriptions##{page}"
@@ -34,16 +33,12 @@ When /^I view the "(.*)" subscription$/ do |sub_name|
 		@subscription = Subscription.where(:subscription_name => sub_name).first
 	end
 	path = "/subscriptions/" + @subscription.id
-	# puts path
 	visit path
 end
 
 When /^I delete the "(.*)" subscription$/ do |sub_name|
-	# puts "UNDEFINED STEP!!!"
-	# accept_confirm do
 	@subscription = Subscription.where(:subscription_name => sub_name).first
 	click_button "Delete"
-	# page.driver.browser.switch_to.confirm.accept
 end
 
 When /^I create a new subscription$/ do

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -32,9 +32,9 @@ def sign_up(visitor_info)
 
 def sign_out
 	visit "/"
-	if page.text.match?("Sign out")
-		click_link "Sign out"
-	end
+	click_link "Sign Out"
+	page.has_content?("Sign Up")
+	page.has_content?("Sign In")
 end
 
 ##### GIVEN #####
@@ -56,6 +56,10 @@ Given /^I am logged in$/ do
 	visit "/users/sign_in"
 	sign_in(@visitor_info)
 	page.has_content?("Sign out")
+end
+Given(/^I am on my profile page$/) do
+	expect(@user.nil? == false)
+	visit "/users/#{@user.username}"
 end
 
 ##### WHEN #####
@@ -92,7 +96,6 @@ When /^I sign up with up a mismatched password and password confirmation$/ do
 end
 
 When /^I login with valid user credentials$/ do
-	# create_visitor
 	sign_in(@visitor_info)
 end
 When /^I login with a wrong email$/ do
@@ -110,7 +113,7 @@ end
 
 ##### THEN #####
 Then /^I am on the sign in page$/ do
-	visit "/users/sign_in"
+	expect(page).to have_current_path("/users/sign_in", wait: true)
 end
 Then /^I should see the profile page$/ do
 	expect(page).to have_current_path("/subscriptions", wait: true)

--- a/features/subscriptions/view_subscription.feature
+++ b/features/subscriptions/view_subscription.feature
@@ -30,6 +30,5 @@ Feature: View Subscription
 	
     Scenario: Unauthenticated user tries to view a subscription
 		Given I am not logged in
-		And I am on the homepage
-		When I view the "Hulu" subscription
-  		Then I should see the resource not found page
+		When I view the "Netflix" subscription
+  		Then I am on the sign in page

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  group_name: MyString
+  subscriptions: one
+  user: one
+
+two:
+  group_name: MyString
+  subscriptions: two
+  user: two

--- a/test/fixtures/memberships.yml
+++ b/test/fixtures/memberships.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  group: one
+
+two:
+  user: two
+  group: two

--- a/test/fixtures/shared_subscriptions.yml
+++ b/test/fixtures/shared_subscriptions.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  subscription: one
+  group: one
+
+two:
+  subscription: two
+  group: two

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class GroupTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MembershipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/shared_subscription_test.rb
+++ b/test/models/shared_subscription_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SharedSubscriptionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### Pivotal Tracker
- https://www.pivotaltracker.com/story/show/181080681

<!-- *** EDIT_NUMBER_INTO_LINK_ABOVE_REPLACING_### ***
    - Include a link to each user story on Pivotal for the user story, bugfix, etc.
    - If there is not an action item for the PR, then consider making one.
-->



### Description / PR Commit Message

<!-- *** COMMENT_DESCRIPTION_PR_COMMIT_MESSAGE ***
    - Add a description of the PR and why it is being made.
    - May contain root cause, perf impact, background info, system design, changes made, creator impact, etc.
    - Upon merging, copy the text you typed below here and use that as the PR Commit Message.
-->
Created data models for groups. 

Includes `Group`s, `SharedSubscription`s, and `Membership`s tables:
- Groups
     - `belongs_to` owner: `user` 
     - `has_many_through` shared_subscriptions: `subscription`
     - `has_many_through` memberships: `user`

- SharedSubscriptions
     - `belongs_to` subscription: `subscription` 
     - `belongs_to` group: `group`

- Membership
     - `belongs_to` user: `user` 
     - `belongs_to` group: `group`
     
- User (update)
     - `has_many` subscriptions: `subscription`
     - `has_many` owned_groups: `group`
     - `has_many_through` memberships: `group`


### Guidance for Review

<!-- *** COMMENT__GUIDANCE_FOR_REVIEW ***
    - Provide additional information to ease review of this PR; this section does not survive into git history.
    - May contain: what you dev tested, perf captures, screenshots, requested feedback, recommended order to review files in, autotest reliability results, changelog exemption reason, test review exemption reason, etc.
-->
`SharedSubscription` and `Membership` are joining tables between `subscription`s and `group`s and `user`s and `group`s respectively. The `through` tag allows you to get the actual reference instead of the join reference. An example of this is with the `shared_subscriptions`/`subscriptions` on `group`s. If you use `group.shared_subscriptions` it will return the set of objects with references to the group and subscription that is shared with the group. If you use `group.subscription` it will return the actual subscription reference.

### Author's Checklist
- [x] Wrote tests?
- [x] Linked to issue in Github?
- [x] Tests passed?
- [x] Test deployment to gatekeeper-tamu-test?
